### PR TITLE
Member Admins can now see all annotations in blind mode

### DIFF
--- a/exact/exact/annotations/static/annotations/js/exact-imageset-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-imageset-viewer.js
@@ -14,7 +14,7 @@ class EXACTImageSetViewer {
 
         this.exact_viewer = undefined;
 
-        this.exact_imageset_sync = new EXACTImageSetSync(image_set_id, gHeaders);
+        this.exact_imageset_sync = new EXACTImageSetSync(image_set_id, gHeaders, this.user_id);
         this.exact_imageset_sync.loadImageSetInformation(this.imageSetInformationLoaded.bind(this), this.exact_imageset_sync)
 
         this.filteredImageInformation = {}

--- a/exact/exact/images/api_views.py
+++ b/exact/exact/images/api_views.py
@@ -588,6 +588,11 @@ class ImageSetViewSet(viewsets.ModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
 
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+        
+        # fust but buggy find a fix! not updated if the image set is changed in any way for example rights changed
         cache_key = request.META["PATH_INFO"] + request.META["QUERY_STRING"]
 
         data = cache.get(cache_key)

--- a/exact/exact/users/api_views.py
+++ b/exact/exact/users/api_views.py
@@ -32,6 +32,7 @@ class TeamViewset(viewsets.ModelViewSet):
        'name': ['exact', 'contains'],
        'members': ['exact'],
        'image_sets': ['exact'],
+       'memberships': ['exact'],
     }
 
     def get_queryset(self):

--- a/exact/exact/users/serializers.py
+++ b/exact/exact/users/serializers.py
@@ -12,13 +12,15 @@ class TeamSerializer(FlexFieldsModelSerializer):
             'name',
             'members',
             'image_sets', 
-            'product_set'
+            'product_set',
+            'memberships'
         ]
 
         expandable_fields = {
             "members": ('exact.users.serializers.UserSerializer', {'read_only': True, 'many': True}),
             "image_sets": ('exact.images.ImageSetSerializer', {'read_only': True, 'many': True}),
             "product_set": ('exact.administration.ProductSerializer', {'read_only': True, 'many': True}),
+            "memberships": ('exact.users.serializers.TeamMembershipSerializer', {'read_only': True, 'many': True}),
         }
 
 class UserSerializer(FlexFieldsModelSerializer):


### PR DESCRIPTION
implemented: https://github.com/ChristianMarzahl/Exact/issues/50


In the competitive image set mode, admins can now see all annotations.

![image](https://user-images.githubusercontent.com/22664224/128024309-220b1c98-3321-48a2-9031-c815df86206a.png)
