### PR TITLE
Obj vis and interact

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ in [UPGRADE.md](https://github.com/ChristianMarzahl/exact/blob/master/UPGRADE.md
 | Ctrl + z  |              | Undo |
 | c         |              | Toggle annotation mode |
 | y         |              | Toggle annotation visibility |
+| b         |              | Push currently selected annotation type into the background |
 | Ctrl,a    |              | Draw annotation on top of existing one |
 | 0,1,2,3,4 |              | Change label of local annotations |
 | 0,1,2,3,4 |  Shift       | Change label of global annotations |

--- a/README.md
+++ b/README.md
@@ -352,9 +352,13 @@ in [UPGRADE.md](https://github.com/ChristianMarzahl/exact/blob/master/UPGRADE.md
 
 | Key       | Modifier     | Function      |
 |-----------|:------------:|:------------------:| 
-| Del       |              | Delete annotation  |
+| Del,x       |              | Delete annotation  |
 | Escape    |              | Cancel editing     |
 | Enter     |              | Confirm / Save     |
+| Ctrl + z  |              | Undo |
+| c         |              | Toggle annotation mode |
+| y         |              | Toggle annotation visibility |
+| Ctrl,a    |              | Draw annotation on top of existing one |
 | 0,1,2,3,4 |              | Change label of local annotations |
 | 0,1,2,3,4 |  Shift       | Change label of global annotations |
 | q         |              | Previous image     |
@@ -363,9 +367,11 @@ in [UPGRADE.md](https://github.com/ChristianMarzahl/exact/blob/master/UPGRADE.md
 | e         |  Shift       | Next frame         |
 | r         |              | Rotate image (Warning: annotations are not affected)        |
 | f         |              | Flip image   (Warning: annotations are not affected)        |
-| s         |              | Scissor         |
-| g         |              | Glue         |
+| s         |              | Scissor (Delete from selected object)        |
+| g         |              | Glue (Add to selected object)        |
+| d         |              | Knife (Draw a line to split objects)         |
 | Mouse wheel|   Shift      | Paint brush         |
+| Arrow keys |              | Move viewing window |
 
 ##### Screening Viewer 
 

--- a/exact/exact/annotations/static/annotations/js/boundingboxes.js
+++ b/exact/exact/annotations/static/annotations/js/boundingboxes.js
@@ -1028,6 +1028,16 @@ class BoundingBoxes {
             });
     }
 
+    pushAnnoTypeToBackground(annotation_type_id)
+    {
+        this.group.children.forEach(el =>
+        {
+            if (el.data.type_id == annotation_type_id)
+            {
+                el.sendToBack()
+            }
+        })
+    }
 
     updateAnnotations(annotations) {
         if (annotations === undefined ||

--- a/exact/exact/annotations/static/annotations/js/boundingboxes.js
+++ b/exact/exact/annotations/static/annotations/js/boundingboxes.js
@@ -1019,7 +1019,7 @@ class BoundingBoxes {
         if (annotations === undefined ||
             annotations.length === 0) {
 
-            return;s
+            return;
         }
 
         for (var annotation of annotations) {

--- a/exact/exact/annotations/static/annotations/js/boundingboxes.js
+++ b/exact/exact/annotations/static/annotations/js/boundingboxes.js
@@ -993,24 +993,38 @@ class BoundingBoxes {
         }
     }
 
-    updateVisbility(annotation_type_id, visibility, disabled_hitTest = undefined ) {
+    updateVisbility(annotation_type_id, visibility, disabled_hitTest = false, keep_interaction = false) {
         var opacity = $('#OpacitySlider')[0].value
 
         this.group.children.filter(function (el) {return el.data.type_id === parseInt(annotation_type_id)})
             .forEach(function (el) {
                 if (visibility === true) {
                     el.fillColor.alpha = opacity
+                    el.strokeColor.alpha = 1.0
                 }
                 else if (visibility === false){
-                    el.fillColor.alpha = 0
+                    if (keep_interaction)
+                    {
+                        el.fillColor.alpha = 0.01
+                        el.strokeColor.alpha = 0.01
+                    }
+                    else
+                    {
+                        el.fillColor.alpha = 0
+                    }
                 }
-
-                el.visible = visibility;
-
-                if (disabled_hitTest != undefined)
+                
+                if (keep_interaction)
                 {
-                    el.locked = disabled_hitTest
+                    el.visible = true
                 }
+                else
+                {
+                    el.visible = visibility;
+                }
+
+                el.locked = disabled_hitTest
+
             });
     }
 

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -1334,26 +1334,43 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
 
     uiLocalAnnotationVisibilityChanged(event) {
         var annotation_type_id = parseInt(event.target.dataset.annotation_type_id);
+        var tristate_option = $("#tristate_option")[0].value
+
+        var visible = true
+        var disabled_hitTest = false
+        var keep_interaction = false
 
         if(event.currentTarget.value == "on")
         {
             event.currentTarget.checked = false
             event.currentTarget.value="off"
+            visible = false
         }
-        else if(event.currentTarget.value == "off")
+        else if(event.currentTarget.value == "off" && (tristate_option == "no_interact"))
         {
             event.currentTarget.indeterminate = true
             event.currentTarget.checked = true
             event.currentTarget.value="indeterminate"
+            visible = true
+            disabled_hitTest = true
         }
-        else if (event.currentTarget.value == "indeterminate")
+        else if(event.currentTarget.value == "off" && (tristate_option == "no_vis"))
+        {
+            event.currentTarget.indeterminate = true
+            event.currentTarget.checked = true
+            event.currentTarget.value="indeterminate"
+            visible = false
+            keep_interaction = true
+        }
+        else
         {
             event.currentTarget.indeterminate = false
             event.currentTarget.checked = true
             event.currentTarget.value="on"
+            visible = true
         }
 
-        this.changeAnnotationTypeVisibility(annotation_type_id, event.currentTarget.checked, event.currentTarget.indeterminate);
+        this.changeAnnotationTypeVisibility(annotation_type_id, visible, disabled_hitTest, keep_interaction);
     }
 
     createDrawingModule(viewer, imageId, imageInformation) {
@@ -1421,8 +1438,8 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
         }
     }
 
-    changeAnnotationTypeVisibility(annotation_type_id, visibility, disabled_hitTest) {
-        this.tool.updateVisbility(annotation_type_id, visibility, disabled_hitTest);
+    changeAnnotationTypeVisibility(annotation_type_id, visibility, disabled_hitTest, keep_interaction) {
+        this.tool.updateVisbility(annotation_type_id, visibility, disabled_hitTest, keep_interaction);
     }
 
     verifyAnnotation(annotation) {

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -513,6 +513,10 @@ class EXACTViewer {
         return;
     }
 
+    handleKeyPress(event) {
+        return;
+    }
+
     handleKeyDown(event){
         return
     }
@@ -643,6 +647,8 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
         this.actionMemory = 50;
         this.currentAction = undefined
 
+        this.insertNewAnno = false
+
         this.initUiEvents(this.annotationTypes);
     }
 
@@ -731,7 +737,10 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                 var new_selected = tool.hitTestObject(imagePoint)
                 var selected_segment = tool.hitTestSegment(imagePoint)
 
-                if(selected_segment !== undefined && !event.originalEvent.ctrlKey && !(event.userData.tool.singlePolyOperation.active || event.userData.tool.multiPolyOperation.active))
+                var insertAnno = (this.userData.insertNewAnno || event.originalEvent.ctrlKey)
+                var polyOpActive = (event.userData.tool.singlePolyOperation.active || event.userData.tool.multiPolyOperation.active)
+
+                if(selected_segment !== undefined && !insertAnno && !polyOpActive)
                 {
                     // a segment to drag is selected, we didnt press ctrl to force a new object, no poly operation is active
                     tool.drag.active = true
@@ -743,7 +752,7 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                         old_item: tool.selection.item.clone({insert: false})
                     }
                 }
-                else if (new_selected == undefined || event.userData.tool.singlePolyOperation.active || event.userData.tool.multiPolyOperation.active || event.originalEvent.ctrlKey)
+                else if (new_selected == undefined || polyOpActive || insertAnno)
                 {
                     // a new object is created
                     if(tool.selection !== undefined) // reset selection, if existing
@@ -1076,6 +1085,9 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                     this.changeAnnotationTypeByKey(9);
                 }
                 break;
+            case 65: //a
+                this.insertNewAnno = false;
+                break;
 
             case 66: //b
                 break;
@@ -1102,10 +1114,19 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
             case 68: //d
                 this.tool.activateMultiPolyOperationByString("KNIFE", this);
                 break;
-            case 90:
+            case 90: // z
                 if(event.ctrlKey){
                     this.undo();
                 }
+        }
+    }
+
+    handleKeyPress(event)
+    {
+        switch (event.keyCode) {
+            case 97: //a
+                this.insertNewAnno = true;
+                break;
         }
     }
     
@@ -1132,6 +1153,7 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
 
 
         $(document).keyup(this.handleKeyUp.bind(this));
+        $(document).keypress(this.handleKeyPress.bind(this));
         $(document).keydown(this.handleKeyDown.bind(this));
         $('select#annotation_type_id').change(this.changeAnnotationTypeByComboxbox.bind(this));
 

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -1090,6 +1090,7 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                 break;
 
             case 66: //b
+                this.pushCurrentAnnoTypeToBackground();
                 break;
             case 67: //c
                 this.viewer.selectionInstance.toggleState();
@@ -1371,6 +1372,12 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
         }
 
         this.changeAnnotationTypeVisibility(annotation_type_id, visible, disabled_hitTest, keep_interaction);
+    }
+
+    pushCurrentAnnoTypeToBackground()
+    {
+        var selected_annotation_type = this.getCurrentAnnotationType();
+        this.tool.pushAnnoTypeToBackground(selected_annotation_type.id)
     }
 
     createDrawingModule(viewer, imageId, imageInformation) {

--- a/exact/exact/annotations/templates/annotations/annotate.html
+++ b/exact/exact/annotations/templates/annotations/annotate.html
@@ -759,10 +759,15 @@
 
                                         {% endfor %}
                                     </select>
-                                    <tr>
-                                        <input type="checkbox" id="display_messages" checked="true">
-                                        Display Messages
-                                    </tr>
+                                    <div class=""><input type="checkbox" id="display_messages" checked="true" width: auto>Display Messages</div>
+                                    <div class="">
+                                        <label for="tristate_option">3rd Checkbox state:</label>
+                                        <select id="tristate_option">
+                                        <option value="unused">Deactivated</option>
+                                        <option value="no_interact">Visible, no Interaction</option>
+                                        <option value="no_vis">Not Visible, Interaction</option>
+                                        </select>
+                                    </div>
                                 </div>
                             </div>
                         </tr>


### PR DESCRIPTION
Added Options for the function of the 3rd checkbox state:
- Deactivated
- Annotations are visual, but can not be interacted with
- Annotations are not visual, but can be interacted with

Added hotkey option "b" to push the current annotation type into the background (is visualized behind all others)
Added hotkey "a" as secondary option to create new objects on top of existing ones (due to problems with "ctrl" on mac)

Updated hotkeys in the Readme file
