### PR TITLE
Fixed screening mode (undefined variable issue)

### DIFF
--- a/exact/exact/annotations/static/annotations/js/annotations.js
+++ b/exact/exact/annotations/static/annotations/js/annotations.js
@@ -51,7 +51,7 @@ function include_server_subdir(url) {
         $(document).on('click', '.notifyjs-bootstrap-info', function (event) {
             if ($(this).text().trim() === "Start Screening") {
                 var result = globals.screeningTool.getCurrentPosition();
-                viewCoordinates(result['x_min'], result['y_min'], result['x_max'], result['y_max']);
+                viewCoordinates(result['x_min'], result['y_min'], result['x_max']-result['x_min'], result['y_max']-result['y_min']);
 
             } else {
                 var id = parseInt($(this).text().split(" ")[1]);

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -341,7 +341,7 @@ class EXACTViewer {
             var coordinates = event.coordinates;
 
             event.userData.browser_sync.sendCurrentViewPortCoordinates(coordinates);
-            event.userData.viewCoordinates(coordinates.x_min, coordinates.y_min, coordinates.x_max, coordinates.y_max);
+            event.userData.viewCoordinates(coordinates.x_min, coordinates.y_min, coordinates.x_max-coordinates.x_min, coordinates.y_max-coordinates.y_min);
 
         }, this);
 

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -341,7 +341,7 @@ class EXACTViewer {
             var coordinates = event.coordinates;
 
             event.userData.browser_sync.sendCurrentViewPortCoordinates(coordinates);
-            event.userData.viewCoordinates(coordinates.x_min, coordinates.y_min, coordinates.x_max, coordinates.y_max, rotation_angle.rotation_angle);
+            event.userData.viewCoordinates(coordinates.x_min, coordinates.y_min, coordinates.x_max, coordinates.y_max);
 
         }, this);
 


### PR DESCRIPTION
As written in #80, the screening mode has stopped working (discovered by Christof). This is apparently due to a small bug that used a non-existant parameter in a function call. The parameter (rotation_angle) is however not necessary for the function call. 