### PR TITLE
Adv anno mods

### DIFF
--- a/exact/exact/annotations/static/annotations/js/boundingboxes.js
+++ b/exact/exact/annotations/static/annotations/js/boundingboxes.js
@@ -1260,6 +1260,21 @@ class BoundingBoxes {
         return undefined;
     }
 
+    hitTestObject_s(point)
+    {
+        // return the smallest clicked object
+        var hits = this.group.hitTestAll(point, this.hitOptionsObject);
+        if (hits.length > 0)
+        {
+            hits.sort((a,b) => (Math.abs(a.item.area) > Math.abs(b.item.area)) ? 1 : -1)
+            return hits[0]
+        }
+        else
+        {
+            return undefined
+        }
+    }
+
     hitTestSegment(point) {
         if (this.selection !== undefined) {
             var hits = this.group.hitTestAll(point, this.hitOptionsSegment[this.selection.item.data.type])

--- a/exact/exact/annotations/static/annotations/js/exact-imageset-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-imageset-viewer.js
@@ -27,14 +27,20 @@ class EXACTImageSetViewer {
         if (["textarea", "text", "number"].includes(event.target.type))
             return;
 
+        var is_selecting = false
+        if (this.exact_viewer != undefined)
+        {
+            is_selecting = this.exact_viewer.viewer.selectionInstance.isSelecting
+        }
+
         switch (event.keyCode) {
             case 69: //e load next image
-                if (!event.shiftKey) {
+                if (!event.shiftKey && !is_selecting) {
                     this.loadAdjacentImage(1);
                 }                
                 break;
             case 81: //q load last image
-                if (!event.shiftKey) {
+                if (!event.shiftKey && !is_selecting) {
                     this.loadAdjacentImage(-1);
                 }
                 break;

--- a/exact/exact/annotations/static/annotations/js/openseadragon-scalebar.js
+++ b/exact/exact/annotations/static/annotations/js/openseadragon-scalebar.js
@@ -238,10 +238,10 @@
                     !this.drawScalebar ||
                     !this.pixelsPerMeter ||
                     !this.location) {
-                this.divElt.style.display = "none";
+                //this.divElt.style.display = "none";
                 return;
             }
-            this.divElt.style.display = "";
+            //this.divElt.style.display = "";
 
             var viewport = this.viewer.viewport;
             var tiledImage = this.viewer.world.getItemAt(this.referenceItemIdx);


### PR DESCRIPTION
-**Fixed re-appearing scalebar**:  When the map and scalebar where deactivated (map symbol), the scalebar reappeared once the image was moved

-**Blocked Q and E in annotation mode**: The Q and E buttons to change the current slide where active in annotation mode, leading to accidental switching of the slide. These buttons are now only active if annotation mode is deactivated

-**Added fast annotation mode**: If exactly **one** digit is pressed, the corresponding label is directly assigned to the smallest annotation that is clicked